### PR TITLE
VPCのIDをOutputに出力する

### DIFF
--- a/modules/vpc/output.tf
+++ b/modules/vpc/output.tf
@@ -7,3 +7,8 @@ output "private_subnet_ids" {
   description = "Private SubnetのID一覧"
   value       = aws_subnet.private.*.id
 }
+
+output "vpc_id" {
+  description = "VPCのID"
+  value       = aws_vpc.default.id
+}

--- a/output.tf
+++ b/output.tf
@@ -2,3 +2,8 @@ output "eks_create_command" {
   description = "EKSのクラスター作成時に使用するコマンド"
   value       = "eksctl create cluster --name eks-handson --vpc-public-subnets ${join(",", module.vpc.public_subnet_ids)} --vpc-private-subnets ${join(",", module.vpc.private_subnet_ids)} --without-nodegroup"
 }
+
+output "vpc_id" {
+  description = "VPCのID"
+  value       = module.vpc.vpc_id
+}


### PR DESCRIPTION
EKSハンズオンの中でalb-ingress-controllerを作成する．
しかし，そこでvpc_idを設定しなければならないが，現状ではawsコンソールから確認するしかなかった．

さすがに手間なので，ここでvpc_idを出力するようにしておいた．